### PR TITLE
Upgrade Mongoose

### DIFF
--- a/database.js
+++ b/database.js
@@ -2,7 +2,8 @@
 
 var mongoose = require('mongoose');
 
-mongoose.connect(process.env.MONGODB_URI || 'mongodb://database:27017/event-listings');
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://database:27017/event-listings',
+    { useMongoClient: true });
 
 var db = mongoose.connection;
 db.on('error', function(err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,8 @@
     },
     "async": {
       "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "asynckit": {
       "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -180,9 +181,9 @@
       }
     },
     "bluebird": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-      "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
     },
     "body-parser": {
       "version": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
@@ -243,9 +244,14 @@
       "dev": true
     },
     "bson": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
-      "integrity": "sha1-5louPHUH/63kEJvHV1p25Q+NqRU="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
+      "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -642,6 +648,11 @@
       "requires": {
         "is-arrayish": "0.2.1"
       }
+    },
+    "es6-promise": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
     },
     "escape-html": {
       "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1406,9 +1417,9 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "hooks-fixed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.1.0.tgz",
-      "integrity": "sha1-DowVM2cI5mERhf45C0RofdUjDbs="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.2.tgz",
+      "integrity": "sha512-YurCM4gQSetcrhwEtpQHhQ4M7Zo7poNGqY4kQGeBS6eZtOcT3tnNs01ThFa0jYBByAiYt1MjMjP/YApG0EnAvQ=="
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -1611,6 +1622,11 @@
       "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1749,9 +1765,9 @@
       }
     },
     "kareem": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.0.1.tgz",
-      "integrity": "sha1-eAXSFbtTIU7Dr5aaHQsfF+PnuVw="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz",
+      "integrity": "sha1-4+QQHZ3P3imXadr0tNtk2JXRdEg="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -1812,8 +1828,7 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -1865,6 +1880,11 @@
         "lodash._basecreate": "3.0.3",
         "lodash._isiterateecall": "3.0.9"
       }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -2157,85 +2177,64 @@
         }
       }
     },
-    "mongoose": {
-      "version": "4.4.20",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.4.20.tgz",
-      "integrity": "sha1-6XT/tq6MUPQJgBqEl6mOnztR8t0=",
+    "mongodb": {
+      "version": "2.2.33",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
+      "integrity": "sha1-tTfEcdNKZlG0jzb9vyl1A0Dgi1A=",
       "requires": {
-        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "bson": "0.4.23",
-        "hooks-fixed": "1.1.0",
-        "kareem": "1.0.1",
-        "mongodb": "2.1.18",
-        "mpath": "0.2.1",
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.17",
+        "readable-stream": "2.2.7"
+      }
+    },
+    "mongodb-core": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.17.tgz",
+      "integrity": "sha1-pBizN6FKFJkPtRC5I97mqBMXPfg=",
+      "requires": {
+        "bson": "1.0.4",
+        "require_optional": "1.0.1"
+      }
+    },
+    "mongoose": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.13.5.tgz",
+      "integrity": "sha512-xcQ2Igh7hZwrxeBSh1eTW0dC0leQfcj2YA/VfOj/2nBqa5Iab3I8W3ivvs228Jw5qQqtvId1rnXW/QEHEVBNMw==",
+      "requires": {
+        "async": "2.1.4",
+        "bson": "1.0.4",
+        "hooks-fixed": "2.0.2",
+        "kareem": "1.5.0",
+        "lodash.get": "4.4.2",
+        "mongodb": "2.2.33",
+        "mpath": "0.3.0",
         "mpromise": "0.5.5",
-        "mquery": "1.11.0",
-        "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-        "muri": "1.1.0",
+        "mquery": "2.3.3",
+        "ms": "2.0.0",
+        "muri": "1.3.0",
         "regexp-clone": "0.0.1",
         "sliced": "1.0.1"
       },
       "dependencies": {
-        "es6-promise": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-          "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "mongodb": {
-          "version": "2.1.18",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
-          "integrity": "sha1-KNQLUVsr5NWmn/3UxTXw30MuQJc=",
+        "async": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+          "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
           "requires": {
-            "es6-promise": "3.0.2",
-            "mongodb-core": "1.3.18",
-            "readable-stream": "1.0.31"
+            "lodash": "4.17.4"
           }
         },
-        "mongodb-core": {
-          "version": "1.3.18",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
-          "integrity": "sha1-kGhLO3xzVtZa41Y5HTCw8kiATHo=",
-          "requires": {
-            "bson": "0.4.23",
-            "require_optional": "1.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.31",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
-          "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
-          "requires": {
-            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "require_optional": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-          "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-          "requires": {
-            "resolve-from": "2.0.0",
-            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
     "mpath": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz",
-      "integrity": "sha1-Ok6Ck1mAHeljCcJ6ay4QLon56W4="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
+      "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q="
     },
     "mpromise": {
       "version": "0.5.5",
@@ -2243,16 +2242,29 @@
       "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
     },
     "mquery": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-1.11.0.tgz",
-      "integrity": "sha1-4MZd7bEDftv2z7iCYud3/uI1Udk=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.3.tgz",
+      "integrity": "sha512-NC8L14kn+qxJbbJ1gbcEMDxF0sC3sv+1cbRReXXwVvowcwY1y9KoVZFq0ebwARibsadu8lx8nWGvm3V0Pf0ZWQ==",
       "requires": {
-        "bluebird": "2.10.2",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+        "bluebird": "3.5.0",
+        "debug": "2.6.9",
         "regexp-clone": "0.0.1",
         "sliced": "0.0.5"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
         "sliced": {
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
@@ -2265,9 +2277,9 @@
       "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
     },
     "muri": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/muri/-/muri-1.1.0.tgz",
-      "integrity": "sha1-o6bXTmiogPQzokmnSWnLtmXMCt0="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/muri/-/muri-1.3.0.tgz",
+      "integrity": "sha512-FiaFwKl864onHFFUV/a2szAl7X0fxVlSKNdhTf+BM8i8goEgYut8u5P9MqQqIYwvaMxjzVESsoEm/2kfkFH1rg=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -4147,8 +4159,7 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
       "version": "2.0.0",
@@ -4223,6 +4234,20 @@
         }
       }
     },
+    "readable-stream": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+      "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+      "requires": {
+        "buffer-shims": "1.0.0",
+        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
     "regexp-clone": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
@@ -4290,6 +4315,15 @@
           "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
           "dev": true
         }
+      }
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "2.0.0",
+        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
       }
     },
     "resolve": {
@@ -4597,6 +4631,21 @@
           "requires": {
             "ansi-regex": "3.0.0"
           }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         }
       }
     },
@@ -4911,8 +4960,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,7 +180,8 @@
       }
     },
     "bluebird": {
-      "version": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
       "integrity": "sha1-AkpVFylTCIV/FPkfEQb8O1VfRGs="
     },
     "body-parser": {
@@ -242,7 +243,8 @@
       "dev": true
     },
     "bson": {
-      "version": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
       "integrity": "sha1-5louPHUH/63kEJvHV1p25Q+NqRU="
     },
     "builtin-modules": {
@@ -640,10 +642,6 @@
       "requires": {
         "is-arrayish": "0.2.1"
       }
-    },
-    "es6-promise": {
-      "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-      "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
     },
     "escape-html": {
       "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1408,7 +1406,8 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "hooks-fixed": {
-      "version": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.1.0.tgz",
       "integrity": "sha1-DowVM2cI5mERhf45C0RofdUjDbs="
     },
     "hosted-git-info": {
@@ -1612,10 +1611,6 @@
       "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "isarray": {
-      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1754,7 +1749,8 @@
       }
     },
     "kareem": {
-      "version": "https://registry.npmjs.org/kareem/-/kareem-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.0.1.tgz",
       "integrity": "sha1-eAXSFbtTIU7Dr5aaHQsfF+PnuVw="
     },
     "kind-of": {
@@ -2161,61 +2157,105 @@
         }
       }
     },
-    "mongodb": {
-      "version": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
-      "integrity": "sha1-KNQLUVsr5NWmn/3UxTXw30MuQJc=",
-      "requires": {
-        "es6-promise": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-        "mongodb-core": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz"
-      }
-    },
-    "mongodb-core": {
-      "version": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
-      "integrity": "sha1-kGhLO3xzVtZa41Y5HTCw8kiATHo=",
-      "requires": {
-        "bson": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
-        "require_optional": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz"
-      }
-    },
     "mongoose": {
-      "version": "https://registry.npmjs.org/mongoose/-/mongoose-4.4.20.tgz",
+      "version": "4.4.20",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.4.20.tgz",
       "integrity": "sha1-6XT/tq6MUPQJgBqEl6mOnztR8t0=",
       "requires": {
         "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-        "bson": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
-        "hooks-fixed": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.1.0.tgz",
-        "kareem": "https://registry.npmjs.org/kareem/-/kareem-1.0.1.tgz",
-        "mongodb": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
-        "mpath": "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz",
-        "mpromise": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
-        "mquery": "https://registry.npmjs.org/mquery/-/mquery-1.11.0.tgz",
+        "bson": "0.4.23",
+        "hooks-fixed": "1.1.0",
+        "kareem": "1.0.1",
+        "mongodb": "2.1.18",
+        "mpath": "0.2.1",
+        "mpromise": "0.5.5",
+        "mquery": "1.11.0",
         "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-        "muri": "https://registry.npmjs.org/muri/-/muri-1.1.0.tgz",
-        "regexp-clone": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
-        "sliced": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz"
+        "muri": "1.1.0",
+        "regexp-clone": "0.0.1",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "mongodb": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
+          "integrity": "sha1-KNQLUVsr5NWmn/3UxTXw30MuQJc=",
+          "requires": {
+            "es6-promise": "3.0.2",
+            "mongodb-core": "1.3.18",
+            "readable-stream": "1.0.31"
+          }
+        },
+        "mongodb-core": {
+          "version": "1.3.18",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
+          "integrity": "sha1-kGhLO3xzVtZa41Y5HTCw8kiATHo=",
+          "requires": {
+            "bson": "0.4.23",
+            "require_optional": "1.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.31",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+          "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
+          "requires": {
+            "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "require_optional": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+          "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+          "requires": {
+            "resolve-from": "2.0.0",
+            "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
       }
     },
     "mpath": {
-      "version": "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.2.1.tgz",
       "integrity": "sha1-Ok6Ck1mAHeljCcJ6ay4QLon56W4="
     },
     "mpromise": {
-      "version": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
       "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
     },
     "mquery": {
-      "version": "https://registry.npmjs.org/mquery/-/mquery-1.11.0.tgz",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-1.11.0.tgz",
       "integrity": "sha1-4MZd7bEDftv2z7iCYud3/uI1Udk=",
       "requires": {
-        "bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
+        "bluebird": "2.10.2",
         "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-        "regexp-clone": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
-        "sliced": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
+        "regexp-clone": "0.0.1",
+        "sliced": "0.0.5"
       },
       "dependencies": {
         "sliced": {
-          "version": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
           "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
         }
       }
@@ -2225,7 +2265,8 @@
       "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
     },
     "muri": {
-      "version": "https://registry.npmjs.org/muri/-/muri-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/muri/-/muri-1.1.0.tgz",
       "integrity": "sha1-o6bXTmiogPQzokmnSWnLtmXMCt0="
     },
     "mute-stream": {
@@ -4182,18 +4223,9 @@
         }
       }
     },
-    "readable-stream": {
-      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
-      "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
-      "requires": {
-        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-      }
-    },
     "regexp-clone": {
-      "version": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
       "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
     },
     "repeat-string": {
@@ -4260,14 +4292,6 @@
         }
       }
     },
-    "require_optional": {
-      "version": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
-      "integrity": "sha1-UqhhN6hJco62ClVTNhf4+RT1mr8=",
-      "requires": {
-        "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-        "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-      }
-    },
     "resolve": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
@@ -4275,7 +4299,8 @@
       "dev": true
     },
     "resolve-from": {
-      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "restore-cursor": {
@@ -4475,7 +4500,8 @@
       }
     },
     "sliced": {
-      "version": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
       "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "sntp": {
@@ -4573,10 +4599,6 @@
           }
         }
       }
-    },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "body-parser": "1.15.2",
     "express": "^4.13.4",
-    "mongoose": "4.4.20",
+    "mongoose": "4.13.5",
     "parse-post": "0.1.2",
     "request": "2.81.0",
     "validator": "9.1.2"


### PR DESCRIPTION
#5 

1. Mongoose has a dependency on MongoDB.  Upgrade Mongoose to the latest version to fix that dependency.
1. Subsequently, fix the deprecation warning arising from the Mongoose upgrade.

There is no need to upgrade MongoDB via `npm` since we do not have a direct dependency on MongoDB.  In Travis, it is managed via Docker and in production there is a dedicated database.