### PR TITLE
Remove a duplicate of the request module in dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "mocha": "3.5.3",
     "mocha-eslint": "4.1.0",
     "nyc": "11.2.1",
-    "request": "2.81.0",
     "should": "11.2.1",
     "supertest": "3.0.0"
   }


### PR DESCRIPTION
`npm WARN The package request is included as both a dev and production dependency.`